### PR TITLE
Fix multiple evaluations of macro arg in throw+

### DIFF
--- a/src/slingshot/core.clj
+++ b/src/slingshot/core.clj
@@ -44,7 +44,7 @@
         (let [env# (zipmap '~(keys &env) [~@(keys &env)])]
           (Stone.
            "Object thrown by throw+ not caught in any try+:"
-           ~obj
+           obj#
            {:obj obj#
             :env (dissoc env# '~'&throw-context)
             :next (env# '~'&throw-context)}))))))


### PR DESCRIPTION
throw+ evaluates the obj argument multiple times. This rarely causes problems in Clojure, as people usually write side-effect-free code, but it isn't correct, either.
