### PR TITLE
Automatically set the cause on the Stone exception object

### DIFF
--- a/java/src/slingshot/Stone.java
+++ b/java/src/slingshot/Stone.java
@@ -6,7 +6,9 @@ public class Stone extends RuntimeException {
     public final Object object;
     public final Object context;
 
-    public Stone(String _messagePrefix, Object _object, Object _context) {
+    public Stone(String _messagePrefix, Object _object, Object _context,
+                 Throwable cause) {
+        super(cause);
         messagePrefix = _messagePrefix;
         object = _object;
         context = _context;

--- a/src/slingshot/core.clj
+++ b/src/slingshot/core.clj
@@ -52,7 +52,8 @@
               obj#
               {:obj obj#
                :env (dissoc env# '~'&throw-context)
-               :next (env# '~'&throw-context)}))))))
+               :next (env# '~'&throw-context)}
+              (-> (env# '~'&throw-context) meta :throwable)))))))
   ([obj] `(throw+ ~obj "Object thrown by throw+:"))
   ([] `(throw (-> ~'&throw-context meta :throwable))))
 

--- a/test/slingshot/test/core.clj
+++ b/test/slingshot/test/core.clj
@@ -170,3 +170,15 @@
 
 (deftest test-rethrow
   (is (= :zero (h))))
+
+(deftest test-cause
+  (let [e (Exception.)]
+    (try
+      (try+
+       (throw+ e)
+       (catch Exception e
+         (throw+ :a "msg")))
+      (is false)
+      (catch slingshot.Stone s
+        (is (= "msg :a" (.getMessage s)))
+        (is (= e (.getCause s)))))))


### PR DESCRIPTION
When catching a Stone outside of a try+, it should be possible to get the
cause chain, with resourt to Stone specific code. This commit automatically
adds the cause to the Stone exception.
