### PR TITLE
make "catch anything" case clearer with additional selector syntax (Issue 24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,23 @@ Enhanced throw and catch for Clojure
       matches any Object for which the predicate returns a truthy
       value, or
 
+    - the symbol **any**, matches any object thrown by throw or
+      throw+, or
+
     - a **selector form**: a form containing one or more instances of
       `%` to be replaced by the thrown object, matches any object for
       which the form evaluates to truthy.
 
-    - the class name, key-values, and predicate selectors are
+    - the class name, key-values, predicate, and any selectors are
       shorthand for these selector forms:
 
-          `<class name>  => (instance? <class name> %)`
+          <class name> => (instance? <class name> %)
 
-          `[<key> <val> & <kvs>] => (and (= (get % <key>) <val>) ...)`
+          [<key> <val> & <kvs>] => (and (= (get % <key>) <val>) ...)
 
-          `<predicate>   => (<predicate> %)`
+          <predicate> => (<predicate> %)
+
+          any => ((constantly true) %)
 
   - the binding to the caught exception in a catch clause is not
     required to be a simple symbol. It is subject to destructuring so
@@ -145,7 +150,7 @@ math/expression.clj
     (catch [:type :tensor.parse/bad-tree] {:keys [tree hint]}
       (log/error "failed to parse tensor" tree "with hint" hint)
       (throw+))
-    (catch Object _
+    (catch any _
       (log/error (:throwable &throw-context) "unexpected error")
       (throw+))))
 ```

--- a/src/slingshot/slingshot.clj
+++ b/src/slingshot/slingshot.clj
@@ -10,7 +10,7 @@
       throw or throw+;
 
     - specify objects to catch by class name, key-values, predicate,
-      or arbitrary selector form;
+      any, or arbitrary selector form;
 
     - destructure the caught object;
 
@@ -23,12 +23,13 @@
   be replaced by the thrown object. If it evaluates to truthy, the
   object is caught.
 
-    The class name, key-values, and predicate selectors are
+    The class name, key-values, predicate, and any selectors are
     shorthand for these selector forms:
 
       <class name>          => (instance? <class name> %)
       [<key> <val> & <kvs>] => (and (= (get % <key>) <val>) ...)
       <predicate>           => (<predicate> %)
+      any                   -> ((constantly true) %)
 
   The binding form in a try+ catch clause is not required to be a
   simple symbol. It is subject to destructuring which allows easy

--- a/src/slingshot/support.clj
+++ b/src/slingshot/support.clj
@@ -136,7 +136,9 @@
                resolved))))
        (cond-test [selector]
          (letfn
-             [(key-values []
+             [(syntax []
+                ({'any true} selector))
+              (key-values []
                 (and (vector? selector)
                      (if (even? (count selector))
                        `(and ~@(for [[key val] (partition 2 selector)]
@@ -149,7 +151,7 @@
               (predicate []
                 `(~selector ~'%))]
            `(let [~'% (:object ~'&throw-context)]
-              ~(or (key-values) (selector-form) (predicate)))))
+              ~(or (syntax) (key-values) (selector-form) (predicate)))))
        (cond-expression [binding-form expressions]
          `(let [~binding-form (:object ~'&throw-context)]
             ~@expressions))

--- a/test/slingshot/slingshot_test.clj
+++ b/test/slingshot/slingshot_test.clj
@@ -252,7 +252,7 @@
         bump (fn [] (swap! bumps inc))]
     (try+
      (throw+ (bump) "this is it: %s %s %s" % % %)
-     (catch Object _))
+     (catch any _))
     (is (= @bumps 1))))
 
 (deftest test-get-throw-context
@@ -307,7 +307,7 @@
                    (throw+ :afp "wrapper-0")
                    (catch Exception e
                      (throw (RuntimeException. "wrapper-1" e))))
-                 (catch Object _
+                 (catch any _
                    &throw-context))]
     (is (= "wrapper-0" (.getMessage ^Throwable (:wrapper context))))
     (is (= "wrapper-1" (.getMessage ^Throwable (:throwable context))))))
@@ -317,7 +317,7 @@
                       (throw+ {:foo true})
                       (catch #(-> % :foo (= false)) data
                         :caught)
-                      (catch Object _
+                      (catch any _
                         :not-caught)))))
 
 (defn gen-body
@@ -359,7 +359,7 @@
                         ~catch-clause
                         ~else-clause
                         ~finally-clause))
-        (catch Object e#
+        (catch ~'any e#
           ;; if the inner try+ threw, report it as a :bang! in the return vec
           (swap! ~rec-sym #(conj % :bang!))))
        @~rec-sym)))


### PR DESCRIPTION
at long last, a clear syntax for catching any object thrown by throw or throw+.

```
(try+
    ...
    (catch any e
      ...))
```

other syntax symbols could be added. I considered some shorthands for Exception classes (e.g., ex, rte, ex-info), but I didn't see a compelling advantage to those over the class name.
