### PR TITLE
Suppress 'and' clause in keyword catch clause.

### DIFF
--- a/src/slingshot/support.clj
+++ b/src/slingshot/support.clj
@@ -139,8 +139,10 @@
              [(key-values []
                 (and (vector? selector)
                      (if (even? (count selector))
-                       `(and ~@(for [[key val] (partition 2 selector)]
-                                 `(= (get ~'% ~key) ~val)))
+                       (if (= 2 (count selector))
+                         `(= (get ~'% ~(first selector)) ~(second selector))
+                         `(and ~@(for [[key val] (partition 2 selector)]
+                                   `(= (get ~'% ~key) ~val))))
                        (throw-arg "key-values selector: %s does not match: %s"
                                   (pr-str selector) "[key val & kvs]"))))
               (selector-form []


### PR DESCRIPTION
When only one keyword matching argument is present, it's not necessary
to generate an 'and' container. There's no harm either, but linters such
as 'eastwood' may complain.

Example:

    (defn fun []
      (try+
       (something)
       (catch [:key :something] {}
         (recover))))

Macroexpansion before:

    ...
    (contains? &throw-context :catch-hook-rethrow) (throw+)
    (let [% (:object &throw-context)]
      (and (= (get % :key) :something))) (let
                                           [{}

After:

    ...
    (contains? &throw-context :catch-hook-rethrow) (throw+)
    (let [% (:object &throw-context)]
      (= (get % :key) :something)) (let
                                     [{}